### PR TITLE
Fix: Correct camera geolocation data and refine map behavior

### DIFF
--- a/src/components/TrafficMap.tsx
+++ b/src/components/TrafficMap.tsx
@@ -48,10 +48,16 @@ const MapUpdater: React.FC<{ cameras: any[], selectedCamera: string | null }> = 
   const map = useMap();
 
   useEffect(() => {
-    if (cameras.length > 0) {
+    if (cameras.length === 1) {
+      // Center on the single camera with a specific zoom level
+      map.setView([cameras[0].lat, cameras[0].lng], 14); // Use zoom level 14 for a single camera
+    } else if (cameras.length > 1) {
+      // Fit bounds for multiple cameras
       const bounds = L.latLngBounds(cameras.map(camera => [camera.lat, camera.lng]));
       map.fitBounds(bounds, { padding: [20, 20] });
     }
+    // If cameras.length is 0, the map will retain its current view,
+    // which defaults to davenportCenter and zoom={12} as set in MapContainer.
   }, [cameras, map]);
 
   return null;

--- a/src/data/cameraData.ts
+++ b/src/data/cameraData.ts
@@ -26,12 +26,12 @@ export const nextWeekSchedule: WeeklySchedule = {
 
 // Mock geocoded locations - in production, these would come from a geocoding service
 export const mockCameraLocations: CameraLocation[] = [
-  { id: "1", address: "4600 Eastern Ave", lat: 41.5236, lng: -90.5776, active: true, day: "Monday" },
-  { id: "2", address: "3100 Harrison", lat: 41.5520, lng: -90.5890, active: true, day: "Monday" },
-  { id: "3", address: "2600 E River Drive", lat: 41.5300, lng: -90.5400, active: true, day: "Tuesday" },
-  { id: "4", address: "5700 Northwest Blvd", lat: 41.5800, lng: -90.6200, active: true, day: "Tuesday" },
-  { id: "5", address: "5500 Pine St", lat: 41.5100, lng: -90.5900, active: true, day: "Wednesday" },
-  { id: "6", address: "6700 Division St", lat: 41.5400, lng: -90.6100, active: true, day: "Wednesday" },
-  { id: "7", address: "1900 Brady St", lat: 41.5350, lng: -90.5650, active: true, day: "Friday" },
-  { id: "8", address: "900 W Central Park Ave", lat: 41.5280, lng: -90.5820, active: true, day: "Friday" }
+  { id: "1", address: "4600 Eastern Ave", lat: 41.5612, lng: -90.5359, active: true, day: "Monday" },
+  { id: "2", address: "3100 Harrison St", lat: 41.5495, lng: -90.5780, active: true, day: "Monday" }, // Added "St" to address
+  { id: "3", address: "2600 E River Drive", lat: 41.5209, lng: -90.5401, active: true, day: "Tuesday" },
+  { id: "4", address: "5700 Northwest Blvd", lat: 41.5739, lng: -90.6243, active: true, day: "Tuesday" },
+  { id: "5", address: "5500 Pine St", lat: 41.5719, lng: -90.5948, active: true, day: "Wednesday" }, // Corrected original placeholder coords
+  { id: "6", address: "6700 Division St", lat: 41.5407, lng: -90.6458, active: true, day: "Wednesday" },
+  { id: "7", address: "1900 Brady St", lat: 41.5373, lng: -90.5743, active: true, day: "Friday" },
+  { id: "8", address: "900 W Central Park Ave", lat: 41.5281, lng: -90.5913, active: true, day: "Friday" }
 ];


### PR DESCRIPTION
This commit addresses inaccuracies in traffic camera geolocation and improves the map's user experience.

Key changes:
- Updated `src/data/cameraData.ts` with accurate latitude and longitude coordinates for all mock camera locations. Previously, some locations used placeholder or incorrect coordinates.
- Corrected an address string in `cameraData.ts` from "3100 Harrison" to "3100 Harrison St" for accuracy.
- Modified the `MapUpdater` component in `src/components/TrafficMap.tsx` to:
    - Use `map.setView()` with a fixed zoom level (14) when only one camera is active for a selected day, preventing excessive zoom.
    - Retain `map.fitBounds()` for multiple cameras to ensure all are visible.
    - Maintain the default map view if no cameras are scheduled.

These changes ensure that camera markers are displayed at their true locations and that the map's zoom and centering are more consistent and user-friendly across different scenarios.